### PR TITLE
feat: add a power user policy to access ECR

### DIFF
--- a/eks/terraform/main.tf
+++ b/eks/terraform/main.tf
@@ -86,6 +86,9 @@ module "eks" {
       ]
     }
   ]
+  workers_additional_policies = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+  ]
 }
 
 module "jenkinsx" {


### PR DESCRIPTION
Previously, we were creating the EKS clusters passing the `--full-ecr-access` flag to `eksctl`.

This added a power user policy to the worker nodes in order to push to ECR.

This aims to do the same.